### PR TITLE
Fix bluebinder

### DIFF
--- a/bluebinder.c
+++ b/bluebinder.c
@@ -94,7 +94,7 @@ host_write_packet(
 
     gbinder_local_request_init_writer(local_request, &writer);
     // data, without the package type.
-    gbinder_writer_append_hidl_vec(&writer, buf + 1, len - 1, sizeof(uint8_t));
+    gbinder_writer_append_hidl_vec(&writer, (void*)((char*)buf + 1), len - 1, sizeof(uint8_t));
 
     if (((uint8_t*)buf)[0] == HCI_COMMAND_PKT) {
         reply = gbinder_client_transact_sync_reply(proxy->binder_client, 2 /* sendHciCommand */, local_request, &status);

--- a/bluebinder.c
+++ b/bluebinder.c
@@ -370,7 +370,7 @@ bluebinder_callbacks_transact(
 
             *status = GBINDER_STATUS_OK;
 
-            return gbinder_local_object_new_reply(obj);
+            return gbinder_local_reply_append_int32(gbinder_local_object_new_reply(obj), 0);
         } else if (code == 2 || code == 3 || code == 4) {
             unsigned int count, elemsize;
             GBinderReader reader;
@@ -401,7 +401,7 @@ bluebinder_callbacks_transact(
 
             *status = GBINDER_STATUS_OK;
 
-            return gbinder_local_object_new_reply(obj);
+            return gbinder_local_reply_append_int32(gbinder_local_object_new_reply(obj), 0);
         } else {
             fprintf(stderr, "Unknown binder transaction.\n");
             g_main_loop_quit(proxy->loop);

--- a/bluebinder.service
+++ b/bluebinder.service
@@ -5,8 +5,10 @@ Before=bluetooth.service
 
 [Service]
 Type=notify
+ExecStartPre=/usr/bin/droid/bluebinder_wait.sh
 ExecStart=/usr/sbin/bluebinder
 Restart=always
+TimeoutStartSec=60
 
 [Install]
 WantedBy=graphical.target

--- a/bluebinder_wait.sh
+++ b/bluebinder_wait.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+while true
+do
+    bt_status=$(/usr/bin/getprop init.svc.bluetooth-1-0)
+    if [ "$bt_status" = "running" ] ; then
+        exit 0
+    fi
+    echo "Waiting for bluetooth service"
+    sleep 1
+done
+exit 1

--- a/rpm/bluebinder.spec
+++ b/rpm/bluebinder.spec
@@ -1,17 +1,18 @@
-Name:		bluebinder
-Version:	1.0.0
-Release:	1%{?dist}
+Name:           bluebinder
+Version:        1.0.0
+Release:        1%{?dist}
 Summary:        a simple proxy for using android binder based bluetooth through vhci.
 
-Group:		Applications/System
-License:	GPLv2+
-URL:		https://github.com/mer-hybris/bluebinder
-Source:		%{name}-%{version}.tar.bz2
+Group:          Applications/System
+License:        GPLv2+
+URL:            https://github.com/mer-hybris/bluebinder
+Source:         %{name}-%{version}.tar.bz2
 
-BuildRequires:	libgbinder-devel >= 1.0.7
+BuildRequires:  libgbinder-devel >= 1.0.7
 BuildRequires:  pkgconfig(bluez5)
 BuildRequires:  pkgconfig(libsystemd)
-Requires:	bluez5
+Requires:       bluez5
+Requires:       /usr/bin/getprop
 
 %description
 bluebinder is a simple proxy for using android binder based bluetooth through vhci.
@@ -29,9 +30,10 @@ rm -rf $RPM_BUILD_ROOT
 make install DESTDIR=$RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/lib/systemd/system
 cp bluebinder.service $RPM_BUILD_ROOT/lib/systemd/system
-ln -s ../bluebinder.service bluebinder.symlink
 mkdir $RPM_BUILD_ROOT/lib/systemd/system/graphical.target.wants
-mv bluebinder.symlink $RPM_BUILD_ROOT/lib/systemd/system/graphical.target.wants/bluebinder.service
+ln -s ../bluebinder.service $RPM_BUILD_ROOT/lib/systemd/system/graphical.target.wants/bluebinder.service
+mkdir -p $RPM_BUILD_ROOT/usr/bin/droid/
+cp bluebinder_wait.sh $RPM_BUILD_ROOT/usr/bin/droid/
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -42,4 +44,4 @@ make clean
 /usr/sbin/bluebinder
 /lib/systemd/system/graphical.target.wants/bluebinder.service
 /lib/systemd/system/bluebinder.service
-
+/usr/bin/droid/bluebinder_wait.sh


### PR DESCRIPTION
Fixes callback status reporting. Cleanup various issues in exit handling, code style and error reporting.  Start bluebinder only after Android bluetooth service is running. Use GIO functions instead of read/write.